### PR TITLE
「TeX環境の構築」の修正と、英語論文用latexmkrcファイルの確認

### DIFF
--- a/TeX/English/latexmkrc
+++ b/TeX/English/latexmkrc
@@ -1,0 +1,11 @@
+#!/usr/bin/perl
+$latex         = 'pdflatex %O -src-specials -shell-escape -interaction=nonstopmode -synctex=1 %S';
+$bibtex        = 'pbibtex %O %B';
+$dvipdf        = 'dvipdfmx %O -o %D %S';
+$pdf_mode      = 3; # use dvipdfmx
+
+# Use SumatraPDF and atom inverse search
+# $pdf_previewer = '"C:\Program Files\SumatraPDF\SumatraPDF.exe" -reuse-instance -inverse-search "\"%USERPROFILE%\AppData\Local\atom\bin\atom.cmd\" \"%f:%l\"" %O %S';
+
+# if you do not need to preview in -pvc option (preview document and countinuously update mode)
+# $pdf_previewer = 'exit';

--- a/TeX/get_started.md
+++ b/TeX/get_started.md
@@ -11,7 +11,6 @@ TeX のソースコードを文書へ変換するソフトウェア（コンパ�
 様々なパッケージが含まれているので、とりあえずこれをインストールしておけば十分。
 
 `sudo apt-get install texlive-lang-cjk`
-`sudo apt-get install texlive-publishers`
 
 雑誌指定のレイアウトが含まれる texlive-publishers もインストールしておく。
 


### PR DESCRIPTION
+ `TeX/get_started.md`の14行目に、
`sudo apt-get install texlive-publishers`
の表記が２つありましたので、片方を削除しました。

+ `TeX/get_started.md` の65行目
`英語論文用latexmkrcファイル`
のリンク先に指定したファイルがありませんでした。
ご確認の方お願いします。